### PR TITLE
Key is now []byte

### DIFF
--- a/example_clientserver_test.go
+++ b/example_clientserver_test.go
@@ -59,7 +59,7 @@ func Example_serverClientMatch() {
 	}
 
 	// server can now make the key.
-	serverKey, err := server.MakeKey()
+	serverKey, err := server.Key()
 	if err != nil || serverKey == nil {
 		fmt.Printf("something went wrong making server key: %s\n", err)
 	}
@@ -79,7 +79,7 @@ func Example_serverClientMatch() {
 	}
 
 	// client can now make the session key
-	clientKey, err := client.MakeKey()
+	clientKey, err := client.Key()
 	if err != nil || clientKey == nil {
 		fmt.Printf("something went wrong making server key: %s", err)
 	}

--- a/example_clientserver_test.go
+++ b/example_clientserver_test.go
@@ -1,6 +1,7 @@
 package srp
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"math/big"
@@ -87,7 +88,7 @@ func Example_serverClientMatch() {
 	// that each know the same key. Here we have both in the same space, so
 	// we just compare
 
-	if serverKey.Cmp(clientKey) == 0 {
+	if bytes.Equal(serverKey, clientKey) {
 		fmt.Println("Keys match")
 	} else {
 		fmt.Println("Uh oh")

--- a/srp.go
+++ b/srp.go
@@ -148,7 +148,7 @@ func (s *SRP) EphemeralPublic() *big.Int {
 // ResetEphemeralPublic should only be used when constructing
 // tests of SRP integration with the consumer.
 //
-// Depreciated: This is for testing only. It is not meant to
+// Deprecated: This is for testing only. It is not meant to
 // be used in real code, and may disappear at any moment.
 func (s *SRP) ResetEphemeralPublic() {
 	s.ephemeralPublicA.Set(bigZero)
@@ -157,7 +157,7 @@ func (s *SRP) ResetEphemeralPublic() {
 // TestOnlySetSecret should only be used when constructing
 // tests of SRP integration with the consumer.
 //
-// Depreciated: This is for testing only. It is not meant to
+// Deprecated: This is for testing only. It is not meant to
 // be used in real code, and may disappear at any moment.
 func (s *SRP) TestOnlySetSecret(secret *big.Int) {
 	s.ephemeralPrivate.Set(secret)

--- a/srp.go
+++ b/srp.go
@@ -158,7 +158,7 @@ type SRP struct {
 	u                *big.Int // calculated scrambling parameter
 	k                *big.Int // multiplier parameter
 	premasterKey     *big.Int // unhashed derived session secret
-	Key              *big.Int // H(premasterKey)
+	Key              []byte   // H(premasterKey)
 	isServer         bool
 	badState         bool
 }
@@ -207,7 +207,7 @@ func newSRP(serverSide bool, group *Group, xORv *big.Int, k *big.Int) *SRP {
 		x:                big.NewInt(0),
 		v:                big.NewInt(0),
 		premasterKey:     big.NewInt(0),
-		Key:              big.NewInt(0),
+		Key:              nil,
 		group:            group,
 		badState:         false,
 
@@ -344,7 +344,7 @@ func (s *SRP) SetOthersPublic(AorB *big.Int) error {
 // (x for client, v for server) will both parties compute the same Key.
 // It is up to the caller to test that both client and server have the same
 // key. (A challange back and forth will do the job)
-func (s *SRP) MakeKey() (*big.Int, error) {
+func (s *SRP) MakeKey() ([]byte, error) {
 	if s.badState {
 		return nil, fmt.Errorf("we've got bad data")
 	}
@@ -390,9 +390,7 @@ func (s *SRP) MakeKey() (*big.Int, error) {
 	h := sha256.New()
 	h.Write([]byte(fmt.Sprintf("%x", s.premasterKey)))
 
-	key := &big.Int{}
-	key.SetBytes(h.Sum(nil))
-	s.Key = key
+	s.Key = h.Sum(nil)
 
 	return s.Key, nil
 }

--- a/srp.go
+++ b/srp.go
@@ -48,7 +48,7 @@ type SRP struct {
 	u                *big.Int // calculated scrambling parameter
 	k                *big.Int // multiplier parameter
 	premasterKey     *big.Int // unhashed derived session secret
-	Key              []byte   // H(premasterKey)
+	key              []byte   // H(preMasterSecret)
 	isServer         bool
 	badState         bool
 }
@@ -99,7 +99,7 @@ func newSRP(serverSide bool, group *Group, xORv *big.Int, k *big.Int) *SRP {
 		x:                big.NewInt(0),
 		v:                big.NewInt(0),
 		premasterKey:     big.NewInt(0),
-		Key:              nil,
+		key:              nil,
 		group:            group,
 		badState:         false,
 
@@ -216,7 +216,7 @@ func (s *SRP) Verifier() (*big.Int, error) {
 func (s *SRP) SetOthersPublic(AorB *big.Int) error {
 	if !s.IsPublicValid(AorB) {
 		s.badState = true
-		s.Key = nil
+		s.key = nil
 		return fmt.Errorf("invalid public exponent")
 	}
 
@@ -228,7 +228,10 @@ func (s *SRP) SetOthersPublic(AorB *big.Int) error {
 	return nil
 }
 
-// MakeKey creates and returns the session Key
+// Key creates and returns the session Key
+//
+// Caller MUST check error status.
+//
 // Once the ephemeral public key is received from the other party and properly
 // set, SRP should have enough information to compute the session key.
 //
@@ -236,7 +239,10 @@ func (s *SRP) SetOthersPublic(AorB *big.Int) error {
 // (x for client, v for server) will both parties compute the same Key.
 // It is up to the caller to test that both client and server have the same
 // key. (A challange back and forth will do the job)
-func (s *SRP) MakeKey() ([]byte, error) {
+func (s *SRP) Key() ([]byte, error) {
+	if s.key != nil {
+		return s.key, nil
+	}
 	if s.badState {
 		return nil, fmt.Errorf("we've got bad data")
 	}
@@ -282,7 +288,18 @@ func (s *SRP) MakeKey() ([]byte, error) {
 	h := sha256.New()
 	h.Write([]byte(fmt.Sprintf("%x", s.premasterKey)))
 
-	s.Key = h.Sum(nil)
+	s.key = h.Sum(nil)
 
-	return s.Key, nil
+	if len(s.key) != h.Size() {
+		return nil, fmt.Errorf("key size should be %d, but instead is %d", h.Size(), len(s.key))
+	}
+	return s.key, nil
+}
+
+// TestOnlyResetKey sets to final key back to nil. This is used only for testing
+// integration with caller
+//
+// Deprecated: This is only used for testing integration with caller. Never if real life
+func (s *SRP) TestOnlyResetKey() {
+	s.key = nil
 }

--- a/srp_test.go
+++ b/srp_test.go
@@ -71,9 +71,9 @@ func TestCalculateClientRawKey(t *testing.T) {
 	client.makeA()
 	client.SetOthersPublic(B)
 	client.u = u
-	key, _ := client.MakeKey()
+	key, _ := client.Key()
 
-	if !bytes.Equal(client.Key, expectedKey) {
+	if !bytes.Equal(client.key, expectedKey) {
 		t.Errorf("key doesn't match expected key.\n%x\n!=\n%x", key, expectedKey)
 	}
 }
@@ -205,10 +205,10 @@ func TestNewSRPAgainstSpec(t *testing.T) {
 
 	// Force use of test vector u
 	server.u = u
-	if retBytes, err = server.MakeKey(); err != nil {
+	if retBytes, err = server.Key(); err != nil {
 		t.Errorf("MakeKey failed: %s", err)
 	}
-	if !bytes.Equal(retBytes, server.Key) {
+	if !bytes.Equal(retBytes, server.key) {
 		t.Error("Key does not equal Key (nobody tell Ayn Rand)")
 	}
 	if premasterSecret.Cmp(server.premasterKey) != 0 {
@@ -272,8 +272,8 @@ func TestClientServerMatch(t *testing.T) {
 	server.SetOthersPublic(A)
 	client.SetOthersPublic(B)
 
-	serverKey, _ := server.MakeKey()
-	clientKey, _ := client.MakeKey()
+	serverKey, _ := server.Key()
+	clientKey, _ := client.Key()
 
 	if server.k.Cmp(client.k) != 0 {
 		t.Error("Server and Client k don't match")
@@ -298,7 +298,7 @@ func TestBadA(t *testing.T) {
 		t.Error("a bad A was accepted")
 	}
 
-	key, err := server.MakeKey()
+	key, err := server.Key()
 	if err == nil {
 		t.Error("no error on key creation after bad B")
 	}

--- a/srp_test.go
+++ b/srp_test.go
@@ -1,6 +1,7 @@
 package srp
 
 import (
+	"bytes"
 	rand "crypto/rand"
 	"encoding/hex"
 	"math/big"
@@ -62,7 +63,7 @@ func TestCalculateClientRawKey(t *testing.T) {
 	B := NumberFromString("780a5495cbf731d2463fd01d28822e7d9ccf697c4239d5151f85666aa06b3767e0301b54cfad3bd2b526d4d8a1d96492e59c8d8ecddca96b7e288f186155ffa57b50df6bc2103b6004400b797334a22d9dd234b40142a5ab714ea6070d2ed55096049f50efba99862b72f7e7aee51ed71ba6663fff570cc713d456316f3535630e87a245f09b0791c6e687baa65bf2dfb5c17e50c250256cdad4c9851a2484e88326888060ae9578b5a60e0c85143b25f4fb4fca794e266a4359642da085672d6a3b881649a387875685aeb1ae3d809bf7818dcad596c6e29d566ae87c0ad645a0fcc2eb4f066c097670adf48cf0954918fda4dc30588261321d592f890eed87a950d387b48cf6b4a49f9d497323f683091ae6a4efe675d6bfc4393c0c3d54c9adad65b8dd3a7b7e85cd5d31e97bebc8f23b370348dab53903ec5085cbf65de5e5491f417e5bf9953f081e788f36c26cbe00664a1256c4befb00765ea7e432af189521442c186f14442b1957e444426f740f363ebda943da2bb3b18a13e2f41be9cc3ca0a1b111f6983f9b8d0ee0f4b573c6042fbc0ca029821ebe517ed0755a94f42d32b0abef9240af0f37b5fe0e90c4ca83acf91d28a7f3acff5657bf69fdb7747e380b23fd437f637da2f7ebcf8733a69a75715fe3894e1799906b48e3ae818332cf5f9533e7af5a1f065f907c8f31fe778fa2da853e69926fc551d6b3ae")
 	u := NumberFromString("dad353365f78590c1857b29f16e3a947df4707868e2dd2d2b4eafd35c8c854a1")
 	k := NumberFromString("4832374a524b354d344e424a584f42434f45544356584a484641")
-	expectedKey := NumberFromString("f6bef3d6fa5a08a849bf61041cd5b3185c16aede851c819a3644fa7e918c4da6")
+	expectedKey, _ := hex.DecodeString("f6bef3d6fa5a08a849bf61041cd5b3185c16aede851c819a3644fa7e918c4da6")
 
 	groupID := RFC5054Group4096
 	client := NewSRPClient(KnownGroups[groupID], x, k)
@@ -72,7 +73,7 @@ func TestCalculateClientRawKey(t *testing.T) {
 	client.u = u
 	key, _ := client.MakeKey()
 
-	if client.Key.Cmp(expectedKey) != 0 {
+	if !bytes.Equal(client.Key, expectedKey) {
 		t.Errorf("key doesn't match expected key.\n%x\n!=\n%x", key, expectedKey)
 	}
 }
@@ -169,6 +170,7 @@ func TestNewSRPAgainstSpec(t *testing.T) {
 
 	var err error
 	var ret *big.Int
+	var retBytes []byte
 
 	// Our calculation of k is not compatable with RFC5054
 	if server.k.Cmp(k) != 0 {
@@ -203,10 +205,10 @@ func TestNewSRPAgainstSpec(t *testing.T) {
 
 	// Force use of test vector u
 	server.u = u
-	if ret, err = server.MakeKey(); err != nil {
+	if retBytes, err = server.MakeKey(); err != nil {
 		t.Errorf("MakeKey failed: %s", err)
 	}
-	if ret.Cmp(server.Key) != 0 {
+	if !bytes.Equal(retBytes, server.Key) {
 		t.Error("Key does not equal Key (nobody tell Ayn Rand)")
 	}
 	if premasterSecret.Cmp(server.premasterKey) != 0 {
@@ -270,8 +272,8 @@ func TestClientServerMatch(t *testing.T) {
 	server.SetOthersPublic(A)
 	client.SetOthersPublic(B)
 
-	server.MakeKey()
-	client.MakeKey()
+	serverKey, _ := server.MakeKey()
+	clientKey, _ := client.MakeKey()
 
 	if server.k.Cmp(client.k) != 0 {
 		t.Error("Server and Client k don't match")
@@ -279,10 +281,9 @@ func TestClientServerMatch(t *testing.T) {
 	if server.u.Cmp(client.u) != 0 {
 		t.Error("Server and Client u don't match")
 	}
-	if server.Key.Cmp(client.Key) != 0 {
+	if !bytes.Equal(serverKey, clientKey) {
 		t.Error("Server and Client keys don't match")
 	}
-
 }
 
 func TestBadA(t *testing.T) {


### PR DESCRIPTION
## Interface changes

1. The returned key at the end is now [32]byte instead of a big int.
2. MakeKey() has been replaced by Key()
3. struct member for the key is no longer exported, use getter Key()
4. A TestOnlyResetKey() method has been added just in case user needs to test things and remake the key.

### Rationale

1. []byte instead of big Int. Seriously? Who needs a big int when they are expecting something that will be a session key. Also this better fits the semantics of SRP. It is the output of a hash.

2. s/MakeKey()/Key()/g. Now this looks like the other getters. Also (like the others) it won't remake something that has already has been made.

3. This just follows from 2.

4. If external tests need to manually set A or B, then we need to be able to remake the Key. So this method resets the Key to nil.

Rant. I do not like golang's concept of zero. I do not like it on a train; I do not like it in the rain. Either I'm doing it wrong (possible) or this is like the bad old days of using various zeros to signal state instead of as meaningful values.
